### PR TITLE
fix: prefix Go publish App token with x-access-token

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -438,7 +438,11 @@ export class CdktnProviderProject extends cdk.JsiiProject {
         ),
         JsonPatch.add(
           "/jobs/release_golang/steps/17/env/GITHUB_TOKEN",
-          goPublishToken.tokenRef
+          // GitHub App installation tokens (ghs_*) require the `x-access-token`
+          // username when used in HTTPS git URLs. publib renders this env var
+          // verbatim into `https://${GITHUB_TOKEN}@github.com/...`, so without
+          // the prefix the push 401s and falls back to a TTY password prompt.
+          `x-access-token:${goPublishToken.tokenRef}`
         )
       );
     }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -3396,7 +3396,7 @@ jobs:
         env:
           GIT_USER_NAME: team-cdk-terrain
           GIT_USER_EMAIL: github-team-cdk-terrain@cdktn.io
-          GITHUB_TOKEN: \${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:\${{ steps.generate_token.outputs.token }}
         run: npx -p publib@latest publib-golang
       - name: Extract Version
         id: extract-version
@@ -6394,7 +6394,7 @@ jobs:
         env:
           GIT_USER_NAME: team-cdk-terrain
           GIT_USER_EMAIL: github-team-cdk-terrain@cdktn.io
-          GITHUB_TOKEN: \${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:\${{ steps.generate_token.outputs.token }}
         run: npx -p publib@latest publib-golang
       - name: Extract Version
         id: extract-version
@@ -9392,7 +9392,7 @@ jobs:
         env:
           GIT_USER_NAME: team-cdk-terrain
           GIT_USER_EMAIL: github-team-cdk-terrain@cdktn.io
-          GITHUB_TOKEN: \${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:\${{ steps.generate_token.outputs.token }}
         run: npx -p publib@latest publib-golang
       - name: Extract Version
         id: extract-version
@@ -12392,7 +12392,7 @@ jobs:
         env:
           GIT_USER_NAME: team-cdk-terrain
           GIT_USER_EMAIL: github-team-cdk-terrain@cdktn.io
-          GITHUB_TOKEN: \${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:\${{ steps.generate_token.outputs.token }}
         run: npx -p publib@latest publib-golang
       - name: Extract Version
         id: extract-version
@@ -15404,7 +15404,7 @@ jobs:
         env:
           GIT_USER_NAME: team-cdk-terrain
           GIT_USER_EMAIL: github-team-cdk-terrain@cdktn.io
-          GITHUB_TOKEN: \${{ steps.generate_token.outputs.token }}
+          GITHUB_TOKEN: x-access-token:\${{ steps.generate_token.outputs.token }}
         run: npx -p publib@latest publib-golang
       - name: Extract Version
         id: extract-version


### PR DESCRIPTION
## Summary
- Prepend `x-access-token:` to the App-installation token reference in the `release_golang` GITHUB_TOKEN env, so publib renders the git remote URL in the form GitHub's git server requires for `ghs_*` tokens.

## Context
PR #21 (`feat: Use GitHub App to publish Go`, #21) replaced the revoked `GO_GITHUB_TOKEN` PAT with a per-target App-installation token. After AWS upgraded to the new `@cdktn/provider-project` (cdktn-io/cdktn-provider-aws commit `1a78bfa`, run [25474888974](https://github.com/cdktn-io/cdktn-provider-aws/actions/runs/25474888974)), the Go publish reproduced the same failure as the pre-switch run:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
Command failed: git push origin aws/v24.0.0
    at Object.push (publib/lib/help/git.js:193:11)
    at /publib/lib/targets/go.js:130:35
```

## Root cause
`publib`'s `lib/help/git.ts` constructs the git remote URL as:

```ts
return `https://${gitHubToken}@${repositoryUrl}.git`;
```

That puts whatever's in `GITHUB_TOKEN` in the URL's *user* position with no password. GitHub's git server accepts it for classic PATs (`ghp_*`) — that's why `GO_GITHUB_TOKEN` worked until it was revoked. App installation tokens (`ghs_*`) require the literal username `x-access-token` with the token in the password position:

```
https://x-access-token:ghs_TOKEN@github.com/owner/repo.git
```

The `team-cdk-terrain` GitHub App is correctly installed (org-wide All-repositories access, Read & write on `code` etc.), the `Generate token` step succeeds, and the `cdktn-provider-*-go` repos are reachable to it — the token just wasn't being framed in the shape GitHub expects.

PR #21 was copied from [mrgrain/cdk-esbuild@33b24b4](https://github.com/mrgrain/cdk-esbuild/commit/33b24b4a41378e56ad4cd9f081ec5a63d5505c32), which had the same omission. Mrgrain has since fixed it on the `v5` branch:

> [`projenrc/ReleaseBranches.ts:143`](https://github.com/mrgrain/cdk-esbuild/blob/fc90b70fb54c4423cb6e0ac47b7b861c8ffd921a/projenrc/ReleaseBranches.ts#L143)
> ```ts
> JsonPatch.add('/jobs/release_golang/steps/11/env/GITHUB_TOKEN', `x-access-token:${goPublishToken.tokenRef}`),
> ```

## Change
One-line edit in `src/index.ts` at the second `JsonPatch.add` of the `release_golang` patch block. Snapshot updates only touch the five `release_golang` `GITHUB_TOKEN` lines.

## Test plan
- [x] `yarn test -u` — exactly five snapshots updated, all `release_golang` `GITHUB_TOKEN` lines.
- [x] `git diff test/__snapshots__/index.test.ts.snap` — confirmed only the expected hunks.
- [x] `npx projen validate-workflows` — passes.
- [ ] After merge & auto-release, verify the next provider release's `Publish to GitHub Go Module Repository` job exits 0 and tags `cdktn-io/cdktn-provider-<name>-go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)