### PR TITLE
fix: Make sure token creation has the needed inputs

### DIFF
--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -98,8 +98,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
         with:
-          app-id: ${{ env.PROJEN_APP_ID }}
-          private-key: ${{ env.PROJEN_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PROJEN_APP_ID }}
+          private-key: ${{ secrets.PROJEN_APP_PRIVATE_KEY }}
       - name: Get GitHub App User ID
         id: get_user_id
         env:

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -174,8 +174,8 @@ export class UpgradeNode {
             id: "generate_token",
             uses: "actions/create-github-app-token",
             with: {
-              "app-id": "${{ env.PROJEN_APP_ID }}",
-              "private-key": "${{ env.PROJEN_APP_PRIVATE_KEY }}",
+              "app-id": "${{ secrets.PROJEN_APP_ID }}",
+              "private-key": "${{ secrets.PROJEN_APP_PRIVATE_KEY }}",
             },
           },
           {


### PR DESCRIPTION
The node upgrade workflow is currently failing with:
```
Error: [@octokit/auth-app] appId option is required
```

See https://github.com/cdktn-io/cdktn-provider-project/actions/runs/26435816438/job/77818361817

I believe this is the result of trying to reference environment variables that haven't been set.
This PR bypasses the environment variables and just references the secrets directly to keep things simple.